### PR TITLE
Avoid warnings about protocol

### DIFF
--- a/test_truststore.py
+++ b/test_truststore.py
@@ -32,7 +32,7 @@ failure_hosts = pytest.mark.parametrize(
 def connect_to_host(host: str, use_server_hostname: bool = True):
     sock = socket.create_connection((host, 443))
     try:
-        ctx = TruststoreSSLContext()
+        ctx = TruststoreSSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.wrap_socket(sock, server_hostname=host if use_server_hostname else None)
     finally:
         sock.close()
@@ -54,7 +54,7 @@ def test_failures(host):
 
 @successful_hosts
 def test_sslcontext_api_success(host):
-    ctx = TruststoreSSLContext()
+    ctx = TruststoreSSLContext(ssl.PROTOCOL_TLS_CLIENT)
     http = urllib3.PoolManager(ssl_context=ctx)
     resp = http.request("GET", f"https://{host}")
     assert resp.status == 200
@@ -64,7 +64,7 @@ def test_sslcontext_api_success(host):
 @successful_hosts
 @pytest.mark.asyncio
 async def test_sslcontext_api_success_async(host):
-    ctx = TruststoreSSLContext()
+    ctx = TruststoreSSLContext(ssl.PROTOCOL_TLS_CLIENT)
     async with aiohttp.ClientSession() as http:
         resp = await http.request("GET", f"https://{host}", ssl=ctx)
 
@@ -77,7 +77,7 @@ def test_sslcontext_api_failures(host):
     if platform.system() == "Linux" and host == "revoked.badssl.com":
         pytest.skip("Linux currently doesn't support CRLs")
 
-    ctx = TruststoreSSLContext()
+    ctx = TruststoreSSLContext(ssl.PROTOCOL_TLS_CLIENT)
     http = urllib3.PoolManager(ssl_context=ctx)
     with pytest.raises(urllib3.exceptions.SSLError) as e:
         http.request("GET", f"https://{host}", retries=False)
@@ -91,7 +91,7 @@ async def test_sslcontext_api_failures_async(host):
     if platform.system() == "Linux" and host == "revoked.badssl.com":
         pytest.skip("Linux currently doesn't support CRLs")
 
-    ctx = TruststoreSSLContext()
+    ctx = TruststoreSSLContext(ssl.PROTOCOL_TLS_CLIENT)
     async with aiohttp.ClientSession() as http:
         with pytest.raises(
             aiohttp.client_exceptions.ClientConnectorCertificateError


### PR DESCRIPTION
This avoids most of the warnings that are currently provoked by the tests (see below) by explicitly setting the protocol to PROTOCOL_TLS_CLIENT

Before:

```
$ pytest
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.10.2, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/davisagli/Code/truststore
plugins: asyncio-0.18.2
asyncio: mode=legacy
collected 24 items                                                                                                                                                                                         

test_truststore.py ........................                                                                                                                                                          [100%]

============================================================================================= warnings summary =============================================================================================
../../.pyenv/versions/3.10.2/envs/truststore/lib/python3.10/site-packages/pytest_asyncio/plugin.py:191
  /Users/davisagli/.pyenv/versions/3.10.2/envs/truststore/lib/python3.10/site-packages/pytest_asyncio/plugin.py:191: DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

test_truststore.py::test_success[example.com]
test_truststore.py::test_success[1.1.1.1]
test_truststore.py::test_failures[wrong.host.badssl.com]
test_truststore.py::test_failures[expired.badssl.com]
test_truststore.py::test_failures[self-signed.badssl.com]
test_truststore.py::test_failures[untrusted-root.badssl.com]
test_truststore.py::test_failures[superfish.badssl.com]
test_truststore.py::test_failures[revoked.badssl.com]
  /Users/davisagli/Code/truststore/test_truststore.py:35: DeprecationWarning: ssl.SSLContext() without protocol argument is deprecated.
    ctx = TruststoreSSLContext()

test_truststore.py::test_success[example.com]
test_truststore.py::test_success[1.1.1.1]
test_truststore.py::test_failures[wrong.host.badssl.com]
test_truststore.py::test_failures[expired.badssl.com]
test_truststore.py::test_failures[self-signed.badssl.com]
test_truststore.py::test_failures[untrusted-root.badssl.com]
test_truststore.py::test_failures[superfish.badssl.com]
test_truststore.py::test_failures[revoked.badssl.com]
  /Users/davisagli/Code/truststore/test_truststore.py:35: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
    ctx = TruststoreSSLContext()

test_truststore.py: 24 warnings
  /Users/davisagli/Code/truststore/truststore.py:435: DeprecationWarning: ssl.SSLContext() without protocol argument is deprecated.
    self._ctx = ssl.SSLContext(protocol)

test_truststore.py: 24 warnings
  /Users/davisagli/Code/truststore/truststore.py:435: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
    self._ctx = ssl.SSLContext(protocol)

test_truststore.py::test_sslcontext_api_success[example.com]
test_truststore.py::test_sslcontext_api_success[1.1.1.1]
  /Users/davisagli/Code/truststore/test_truststore.py:57: DeprecationWarning: ssl.SSLContext() without protocol argument is deprecated.
    ctx = TruststoreSSLContext()

test_truststore.py::test_sslcontext_api_success[example.com]
test_truststore.py::test_sslcontext_api_success[1.1.1.1]
  /Users/davisagli/Code/truststore/test_truststore.py:57: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
    ctx = TruststoreSSLContext()

test_truststore.py::test_sslcontext_api_success[example.com]
  /Users/davisagli/.pyenv/versions/3.10.2/envs/truststore/lib/python3.10/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'example.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

test_truststore.py::test_sslcontext_api_success[1.1.1.1]
  /Users/davisagli/.pyenv/versions/3.10.2/envs/truststore/lib/python3.10/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host '1.1.1.1'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

test_truststore.py::test_sslcontext_api_success_async[example.com]
test_truststore.py::test_sslcontext_api_success_async[1.1.1.1]
  /Users/davisagli/Code/truststore/test_truststore.py:67: DeprecationWarning: ssl.SSLContext() without protocol argument is deprecated.
    ctx = TruststoreSSLContext()

test_truststore.py::test_sslcontext_api_success_async[example.com]
test_truststore.py::test_sslcontext_api_success_async[1.1.1.1]
  /Users/davisagli/Code/truststore/test_truststore.py:67: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
    ctx = TruststoreSSLContext()

test_truststore.py::test_sslcontext_api_failures[wrong.host.badssl.com]
test_truststore.py::test_sslcontext_api_failures[expired.badssl.com]
test_truststore.py::test_sslcontext_api_failures[self-signed.badssl.com]
test_truststore.py::test_sslcontext_api_failures[untrusted-root.badssl.com]
test_truststore.py::test_sslcontext_api_failures[superfish.badssl.com]
test_truststore.py::test_sslcontext_api_failures[revoked.badssl.com]
  /Users/davisagli/Code/truststore/test_truststore.py:80: DeprecationWarning: ssl.SSLContext() without protocol argument is deprecated.
    ctx = TruststoreSSLContext()

test_truststore.py::test_sslcontext_api_failures[wrong.host.badssl.com]
test_truststore.py::test_sslcontext_api_failures[expired.badssl.com]
test_truststore.py::test_sslcontext_api_failures[self-signed.badssl.com]
test_truststore.py::test_sslcontext_api_failures[untrusted-root.badssl.com]
test_truststore.py::test_sslcontext_api_failures[superfish.badssl.com]
test_truststore.py::test_sslcontext_api_failures[revoked.badssl.com]
  /Users/davisagli/Code/truststore/test_truststore.py:80: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
    ctx = TruststoreSSLContext()

test_truststore.py::test_sslcontext_api_failures_async[wrong.host.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[expired.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[self-signed.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[untrusted-root.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[superfish.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[revoked.badssl.com]
  /Users/davisagli/Code/truststore/test_truststore.py:94: DeprecationWarning: ssl.SSLContext() without protocol argument is deprecated.
    ctx = TruststoreSSLContext()

test_truststore.py::test_sslcontext_api_failures_async[wrong.host.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[expired.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[self-signed.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[untrusted-root.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[superfish.badssl.com]
test_truststore.py::test_sslcontext_api_failures_async[revoked.badssl.com]
  /Users/davisagli/Code/truststore/test_truststore.py:94: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
    ctx = TruststoreSSLContext()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================== 24 passed, 99 warnings in 1.70s ======================================================================================

```

After:
```
$ pytest
=========================================================================================== test session starts ============================================================================================
platform darwin -- Python 3.10.2, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/davisagli/Code/truststore
plugins: asyncio-0.18.2
asyncio: mode=legacy
collected 24 items                                                                                                                                                                                         

test_truststore.py ........................                                                                                                                                                          [100%]

============================================================================================= warnings summary =============================================================================================
../../.pyenv/versions/3.10.2/envs/truststore/lib/python3.10/site-packages/pytest_asyncio/plugin.py:191
  /Users/davisagli/.pyenv/versions/3.10.2/envs/truststore/lib/python3.10/site-packages/pytest_asyncio/plugin.py:191: DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================================================== 24 passed, 1 warning in 1.88s =======================================================================================
```