### PR TITLE
Verify leaf cert using wincrypt APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ await http.request("GET", "https://example.com", ssl=ctx)
 Works in the following configurations:
 
 - macOS 10.8+ using Python 3.10+ (via [Security framework](https://developer.apple.com/documentation/security))
+- Windows using Python 3.10+ (via [CryptoAPI](https://docs.microsoft.com/en-us/windows/win32/seccrypto/cryptography-functions#certificate-verification-functions))
 - Linux using any Python version
 
 ## Prior art

--- a/truststore.py
+++ b/truststore.py
@@ -111,7 +111,7 @@ if platform.system() == "Darwin":
         Security.SecTrustSetAnchorCertificates.argtypes = [SecTrustRef, CFArrayRef]
         Security.SecTrustSetAnchorCertificates.restype = OSStatus
 
-        Security.SecTrustSetAnchorCertificatesOnly.argstypes = [SecTrustRef, Boolean]
+        Security.SecTrustSetAnchorCertificatesOnly.argtypes = [SecTrustRef, Boolean]
         Security.SecTrustSetAnchorCertificatesOnly.restype = OSStatus
 
         Security.SecTrustEvaluate.argtypes = [SecTrustRef, POINTER(SecTrustResultType)]
@@ -380,7 +380,300 @@ if platform.system() == "Darwin":
 # ===== Windows =====
 
 elif platform.system() == "Windows":
-    raise ImportError("Windows is not yet supported")
+
+    from ctypes import (
+        POINTER,
+        Structure,
+        WinDLL,
+        WinError,
+        cast,
+        c_char_p,
+        c_ulong,
+        c_void_p,
+        c_wchar_p,
+        pointer,
+        sizeof,
+    )
+    from ctypes.wintypes import (
+        BOOL,
+        DWORD,
+        HANDLE,
+        LONG,
+        LPCSTR,
+        LPCWSTR,
+        LPFILETIME,
+        LPSTR,
+    )
+
+    HCERTCHAINENGINE = HANDLE
+    HCERTSTORE = HANDLE
+    HCRYPTPROV_LEGACY = HANDLE
+
+    class CERT_CONTEXT(Structure):
+        _fields_ = (
+            ("dwCertEncodingType", DWORD),
+            ("pbCertEncoded", c_void_p),
+            ("cbCertEncoded", DWORD),
+            ("pCertInfo", c_void_p),
+            ("hCertStore", HCERTSTORE),
+        )
+
+    PCERT_CONTEXT = POINTER(CERT_CONTEXT)
+    PCCERT_CONTEXT = POINTER(PCERT_CONTEXT)
+
+    class CERT_ENHKEY_USAGE(Structure):
+        _fields_ = (
+            ("cUsageIdentifier", DWORD),
+            ("rgpszUsageIdentifier", POINTER(LPSTR)),
+        )
+
+    PCERT_ENHKEY_USAGE = POINTER(CERT_ENHKEY_USAGE)
+
+    class CERT_USAGE_MATCH(Structure):
+        _fields_ = (
+            ("dwType", DWORD),
+            ("Usage", CERT_ENHKEY_USAGE),
+        )
+
+    class CERT_CHAIN_PARA(Structure):
+        _fields_ = (
+            ("cbSize", DWORD),
+            ("RequestedUsage", CERT_USAGE_MATCH),
+            ("RequestedIssuancePolicy", CERT_USAGE_MATCH),
+            ("dwUrlRetrievalTimeout", DWORD),
+            ("fCheckRevocationFreshnessTime", BOOL),
+            ("dwRevocationFreshnessTime", DWORD),
+            ("pftCacheResync", LPFILETIME),
+            ("pStrongSignPara", c_void_p),
+            ("dwStrongSignFlags", DWORD),
+        )
+
+    PCERT_CHAIN_PARA = POINTER(CERT_CHAIN_PARA)
+
+    class CERT_TRUST_STATUS(Structure):
+        _fields_ = (
+            ("dwErrorStatus", DWORD),
+            ("dwInfoStatus", DWORD),
+        )
+
+    class CERT_CHAIN_ELEMENT(Structure):
+        _fields_ = (
+            ("cbSize", DWORD),
+            ("pCertContext", PCERT_CONTEXT),
+            ("TrustStatus", CERT_TRUST_STATUS),
+            ("pRevocationInfo", c_void_p),
+            ("pIssuanceUsage", PCERT_ENHKEY_USAGE),
+            ("pApplicationUsage", PCERT_ENHKEY_USAGE),
+            ("pwszExtendedErrorInfo", LPCWSTR),
+        )
+
+    PCERT_CHAIN_ELEMENT = POINTER(CERT_CHAIN_ELEMENT)
+
+    class CERT_SIMPLE_CHAIN(Structure):
+        _fields_ = (
+            ("cbSize", DWORD),
+            ("TrustStatus", CERT_TRUST_STATUS),
+            ("cElement", DWORD),
+            ("rgpElement", POINTER(PCERT_CHAIN_ELEMENT)),
+            ("pTrustListInfo", c_void_p),
+            ("fHasRevocationFreshnessTime", BOOL),
+            ("dwRevocationFreshnessTime", DWORD),
+        )
+
+    PCERT_SIMPLE_CHAIN = POINTER(CERT_SIMPLE_CHAIN)
+
+    class CERT_CHAIN_CONTEXT(Structure):
+        _fields_ = (
+            ("cbSize", DWORD),
+            ("TrustStatus", CERT_TRUST_STATUS),
+            ("cChain", DWORD),
+            ("rgpChain", POINTER(PCERT_SIMPLE_CHAIN)),
+            ("cLowerQualityChainContext", DWORD),
+            ("rgpLowerQualityChainContext", c_void_p),
+            ("fHasRevocationFreshnessTime", BOOL),
+            ("dwRevocationFreshnessTime", DWORD),
+        )
+
+    PCERT_CHAIN_CONTEXT = POINTER(CERT_CHAIN_CONTEXT)
+    PCCERT_CHAIN_CONTEXT = POINTER(PCERT_CHAIN_CONTEXT)
+
+    class SSL_EXTRA_CERT_CHAIN_POLICY_PARA(Structure):
+        _fields_ = (
+            ("cbSize", DWORD),
+            ("dwAuthType", DWORD),
+            ("fdwChecks", DWORD),
+            ("pwszServerName", LPCWSTR),
+        )
+    class CERT_CHAIN_POLICY_PARA(Structure):
+        _fields_ = (
+            ("cbSize", DWORD),
+            ("dwFlags", DWORD),
+            ("pvExtraPolicyPara", c_void_p),
+        )
+
+    class CERT_CHAIN_POLICY_STATUS(Structure):
+        _fields_ = (
+            ("cbSize", DWORD),
+            ("dwError", DWORD),
+            ("lChainIndex", LONG),
+            ("lElementIndex", LONG),
+            ("pvExtraPolicyStatus", c_void_p),
+        )
+
+    PCERT_CHAIN_POLICY_PARA = POINTER(CERT_CHAIN_POLICY_PARA)
+    PCERT_CHAIN_POLICY_STATUS = POINTER(CERT_CHAIN_POLICY_STATUS)
+
+    X509_ASN_ENCODING = 0x00000001
+    PKCS_7_ASN_ENCODING = 0x00010000
+    CERT_STORE_PROV_MEMORY = b"Memory"
+    USAGE_MATCH_TYPE_OR = 1
+    OID_PKIX_KP_SERVER_AUTH = c_char_p(b"1.3.6.1.5.5.7.3.1")
+    AUTHTYPE_SERVER = 2
+    CERT_CHAIN_POLICY_SSL = 4
+
+    wincrypt = WinDLL("crypt32.dll")
+
+    def _handle_win_error(result, func, args):
+        if not result:
+            # Note, actually raises OSError after calling GetLastError and FormatMessage
+            # TODO: Wrap in ssl.SSLCertVerificationError?
+            raise WinError()
+        return args
+
+    CertOpenStore = wincrypt.CertOpenStore
+    CertOpenStore.argtypes = (LPCSTR, DWORD, HCRYPTPROV_LEGACY, DWORD, c_void_p)
+    CertOpenStore.restype = HCERTSTORE
+    CertOpenStore.errcheck = _handle_win_error
+
+    CertAddEncodedCertificateToStore = wincrypt.CertAddEncodedCertificateToStore
+    CertAddEncodedCertificateToStore.argtypes = (
+        HCERTSTORE,
+        DWORD,
+        c_char_p,
+        DWORD,
+        DWORD,
+        PCCERT_CONTEXT,
+    )
+    CertAddEncodedCertificateToStore.restype = BOOL
+
+    CertCreateCertificateContext = wincrypt.CertCreateCertificateContext
+    CertCreateCertificateContext.argtypes = (DWORD, c_char_p, DWORD)
+    CertCreateCertificateContext.restype = PCERT_CONTEXT
+    CertCreateCertificateContext.errcheck = _handle_win_error
+
+    CertGetCertificateChain = wincrypt.CertGetCertificateChain
+    CertGetCertificateChain.argtypes = (
+        HCERTCHAINENGINE,
+        PCERT_CONTEXT,
+        LPFILETIME,
+        HCERTSTORE,
+        PCERT_CHAIN_PARA,
+        DWORD,
+        c_void_p,
+        PCCERT_CHAIN_CONTEXT,
+    )
+    CertGetCertificateChain.restype = BOOL
+    CertGetCertificateChain.errcheck = _handle_win_error
+
+    CertVerifyCertificateChainPolicy = wincrypt.CertVerifyCertificateChainPolicy
+    CertVerifyCertificateChainPolicy.argtypes = (
+        c_ulong,
+        PCERT_CHAIN_CONTEXT,
+        PCERT_CHAIN_POLICY_PARA,
+        PCERT_CHAIN_POLICY_STATUS,
+    )
+    CertVerifyCertificateChainPolicy.restype = BOOL
+
+    CertCloseStore = wincrypt.CertCloseStore
+    CertCloseStore.argtypes = (HCERTSTORE, DWORD)
+    CertCloseStore.restype = BOOL
+    CertCloseStore.errcheck = _handle_win_error
+
+    CertFreeCertificateChain = wincrypt.CertFreeCertificateChain
+    CertFreeCertificateChain.argtypes = (PCERT_CHAIN_CONTEXT,)
+
+    CertFreeCertificateContext = wincrypt.CertFreeCertificateContext
+    CertFreeCertificateContext.argtypes = (PCERT_CONTEXT,)
+
+    def _verify_peercerts_impl(
+        cert_chain: List[bytes], server_hostname: Optional[str] = None
+    ):
+        # TODO: Test with intermediate certs; add them to in-memory cert store
+        pCertContext = None
+        ppChainContext = None
+        # hStore = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, None, 0, None)
+        try:
+            # Cert context for leaf cert
+            leaf_cert = cert_chain[0]
+            pCertContext = CertCreateCertificateContext(
+                X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, leaf_cert, len(leaf_cert)
+            )
+
+            # Chain params to match certs for serverAuth extended usage
+            # TODO: check cert revocation
+            cert_enhkey_usage = CERT_ENHKEY_USAGE()
+            cert_enhkey_usage.cUsageIdentifier = 1
+            cert_enhkey_usage.rgpszUsageIdentifier = (c_char_p * 1)(OID_PKIX_KP_SERVER_AUTH)
+            cert_usage_match = CERT_USAGE_MATCH()
+            cert_usage_match.Usage = cert_enhkey_usage
+            chain_params = CERT_CHAIN_PARA()
+            chain_params.RequestedUsage = cert_usage_match
+            chain_params.cbSize = sizeof(chain_params)
+            pChainPara = pointer(chain_params)
+
+            # Get cert chain
+            ppChainContext = pointer(PCERT_CHAIN_CONTEXT())
+            CertGetCertificateChain(
+                None,  # default chain engine
+                pCertContext,  # leaf cert context
+                None,  # current system time
+                None, # hStore,  # additional in-memory cert store
+                pChainPara,  # chain-building parameters
+                0,  # flags
+                None,  # reserved
+                ppChainContext,  # the resulting chain context
+            )
+            pChainContext = ppChainContext.contents
+
+            # Verify cert chain
+            ssl_extra_cert_chain_policy_para = SSL_EXTRA_CERT_CHAIN_POLICY_PARA()
+            ssl_extra_cert_chain_policy_para.cbSize = sizeof(ssl_extra_cert_chain_policy_para)
+            ssl_extra_cert_chain_policy_para.dwAuthType = AUTHTYPE_SERVER
+            ssl_extra_cert_chain_policy_para.fdwChecks = 0
+            if server_hostname:
+                ssl_extra_cert_chain_policy_para.pwszServerName = c_wchar_p(server_hostname)
+            chain_policy = CERT_CHAIN_POLICY_PARA()
+            chain_policy.pvExtraPolicyPara = cast(pointer(ssl_extra_cert_chain_policy_para), c_void_p)
+            chain_policy.cbSize = sizeof(chain_policy)
+            pPolicyPara = pointer(chain_policy)
+            policy_status = CERT_CHAIN_POLICY_STATUS()
+            policy_status.cbSize = sizeof(policy_status)
+            pPolicyStatus = pointer(policy_status)
+            CertVerifyCertificateChainPolicy(
+                CERT_CHAIN_POLICY_SSL,
+                pChainContext,
+                pPolicyPara,
+                pPolicyStatus,
+            )
+
+            # Check status
+            # TODO: Better error messages
+            error_code = policy_status.dwError
+            if error_code:
+                err = ssl.SSLCertVerificationError()
+                err.verify_code = error_code
+                raise err
+        finally:
+            # result = CertCloseStore(hStore, 0)
+            if ppChainContext:
+                CertFreeCertificateChain(ppChainContext.contents)
+            if pCertContext:
+                CertFreeCertificateContext(pCertContext)
+
+    def _configure_context(ctx: ssl.SSLContext):
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
 
 # ===== Linux =====
 else:

--- a/truststore.py
+++ b/truststore.py
@@ -510,6 +510,7 @@ elif platform.system() == "Windows":
             ("dwFlags", DWORD),
             ("pvExtraPolicyPara", c_void_p),
         )
+    PCERT_CHAIN_POLICY_PARA = POINTER(CERT_CHAIN_POLICY_PARA)
 
     class CERT_CHAIN_POLICY_STATUS(Structure):
         _fields_ = (
@@ -519,8 +520,6 @@ elif platform.system() == "Windows":
             ("lElementIndex", LONG),
             ("pvExtraPolicyStatus", c_void_p),
         )
-
-    PCERT_CHAIN_POLICY_PARA = POINTER(CERT_CHAIN_POLICY_PARA)
     PCERT_CHAIN_POLICY_STATUS = POINTER(CERT_CHAIN_POLICY_STATUS)
 
     X509_ASN_ENCODING = 0x00000001
@@ -528,6 +527,7 @@ elif platform.system() == "Windows":
     CERT_STORE_PROV_MEMORY = b"Memory"
     USAGE_MATCH_TYPE_OR = 1
     OID_PKIX_KP_SERVER_AUTH = c_char_p(b"1.3.6.1.5.5.7.3.1")
+    CERT_CHAIN_REVOCATION_CHECK_CHAIN = 0x20000000
     AUTHTYPE_SERVER = 2
     CERT_CHAIN_POLICY_SSL = 4
 
@@ -610,7 +610,6 @@ elif platform.system() == "Windows":
             )
 
             # Chain params to match certs for serverAuth extended usage
-            # TODO: check cert revocation
             cert_enhkey_usage = CERT_ENHKEY_USAGE()
             cert_enhkey_usage.cUsageIdentifier = 1
             cert_enhkey_usage.rgpszUsageIdentifier = (c_char_p * 1)(OID_PKIX_KP_SERVER_AUTH)
@@ -629,7 +628,7 @@ elif platform.system() == "Windows":
                 None,  # current system time
                 None, # hStore,  # additional in-memory cert store
                 pChainPara,  # chain-building parameters
-                0,  # flags
+                CERT_CHAIN_REVOCATION_CHECK_CHAIN,  # flags
                 None,  # reserved
                 ppChainContext,  # the resulting chain context
             )


### PR DESCRIPTION
This fixes https://github.com/sethmlarson/truststore/issues/8 by implementing cert verification using the CryptoAPI in Windows.