### PR TITLE
Set server flag for SecPolicyCreateSSL

### DIFF
--- a/truststore.py
+++ b/truststore.py
@@ -279,12 +279,12 @@ if platform.system() == "Darwin":
                     cf_str_hostname = _bytes_to_cf_string(
                         server_hostname.encode("ascii")
                     )
-                    policy = Security.SecPolicyCreateSSL(False, cf_str_hostname)
+                    policy = Security.SecPolicyCreateSSL(True, cf_str_hostname)
                 finally:
                     if cf_str_hostname:
                         CoreFoundation.CFRelease(cf_str_hostname)
             else:
-                policy = Security.SecPolicyCreateSSL(False, None)
+                policy = Security.SecPolicyCreateSSL(True, None)
 
             certs = None
             try:


### PR DESCRIPTION
I noticed this while looking through the Mac code. https://developer.apple.com/documentation/security/1392592-secpolicycreatessl says "server: Specify true on the client side to return a policy for SSL server certificates." I think that's what we want since we're acting as a client verifying server certs.