### PR TITLE
Avoid double CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 defaults:
   run:


### PR DESCRIPTION
Fixes #25

~I think you'll need to update the required checks in branch protection settings.~