### PR TITLE
Rename 'TruststoreSSLContext' to 'SSLContext'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Verify certificates using OS trust stores. Supports macOS, Windows, and Linux (w
 
 import socket
 import ssl
-from truststore import TruststoreSSLContext
+import truststore
 
 sock = socket.create_connection(("example.com", 443))
-ctx = TruststoreSSLContext(ssl.PROTOCOL_TLS_CLIENT)
+ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 sock = ctx.wrap_socket(sock, server_hostname="example.com")
 
 # Also works with libraries that accept an SSLContext object

--- a/src/truststore/__init__.py
+++ b/src/truststore/__init__.py
@@ -6,7 +6,7 @@ if _sys.version_info < (3, 10):
     raise ImportError("truststore requires Python 3.10 or later")
 del _sys
 
-from ._api import TruststoreSSLContext  # noqa: E402
+from ._api import SSLContext  # noqa: E402
 
-__all__ = ["TruststoreSSLContext"]
+__all__ = ["SSLContext"]
 __version__ = "0.2.0"

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -14,7 +14,7 @@ else:
     from ._openssl import _configure_context, _verify_peercerts_impl
 
 
-class TruststoreSSLContext(ssl.SSLContext):
+class SSLContext(ssl.SSLContext):
     """SSLContext API that uses system certificates on all platforms"""
 
     def __init__(self, protocol: int = ssl.PROTOCOL_TLS) -> None:


### PR DESCRIPTION
The name `TruststoreSSLContext` was namespaced with `TruststoreX` but that's not needed and probably a bit confusing. Easier to only expose the API we're implementing: `SSLContext`.