### PR TITLE
Trust additional root certs on Windows

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,4 +30,5 @@ def lint(session):
 @nox.session(python="3.10")
 def test(session):
     session.install("-rdev-requirements.txt", ".")
-    session.run("pytest", *(session.posargs or ("test_truststore.py",)))
+    session.run("pip", "freeze")
+    session.run("pytest", "-v", "-s", *(session.posargs or ("test_truststore.py",)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ requires-python = ">= 3.10"
 
 [project.urls]
 Home = "https://github.com/sethmlarson/truststore"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"

--- a/test_truststore.py
+++ b/test_truststore.py
@@ -11,6 +11,10 @@ import urllib3.exceptions
 
 import truststore
 
+# Make sure the httpserver doesn't hang
+# if the client drops the connection due to a cert verification error
+socket.setdefaulttimeout(5)
+
 successful_hosts = pytest.mark.parametrize("host", ["example.com", "1.1.1.1"])
 
 failure_hosts_list = [
@@ -32,8 +36,6 @@ failure_hosts = pytest.mark.parametrize(
 
 @pytest.fixture(scope="session")
 def trustme_ca():
-    if platform.system() == "Windows":
-        pytest.skip("Windows doesn't implement custom CA certificates yet")
     ca = trustme.CA()
     yield ca
 


### PR DESCRIPTION
Fixes #9 on Windows

The approach is a bit awkward because Windows doesn't seem to provide a way to trust CA certs from both the system stores and a custom list at the same time. So this is first trying to verify using the default chain engine, then if that fails it creates a custom chain engine referencing just the certs from ssl_context.get_ca_certs(), and tries that.

Some things that may need more work in the future:
- As we've noted before, get_ca_certs() doesn't include certs loaded using `capath` unless they've already been used.
- Currently when falling back to verifying using the custom CA certs, we're passing a flag that disables cert revocation list (CRL) checks. The check was failing because Windows could not access a CRL for the trustme CA.
- It's probably possible to improve performance by caching the root cert store and chain engine as long as the list of CA certs from openssl hasn't changed.