### PR TITLE
Enforce no warnings during tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,4 @@ Home = "https://github.com/sethmlarson/truststore"
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+filterwarnings = ["error"]

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -53,7 +53,11 @@ class SSLContext(ssl.SSLContext):
             suppress_ragged_eofs=suppress_ragged_eofs,
             session=session,
         )
-        _verify_peercerts(ssl_sock, server_hostname=server_hostname)
+        try:
+            _verify_peercerts(ssl_sock, server_hostname=server_hostname)
+        except ssl.SSLError:
+            ssl_sock.close()
+            raise
         return ssl_sock
 
     def wrap_bio(


### PR DESCRIPTION
And avoid a bunch of ResourceWarnings from leaked sockets

Fixes #18 