### PR TITLE
test trustme cert loaded via capath

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
+pyopenssl
 pytest
 pytest-asyncio
 pytest-httpserver


### PR DESCRIPTION
Add a test demonstrating that verification works using CA certs loaded using capath on all platforms.

We use ctx.get_ca_certs() to get the CA certs to pass to the OS APIs. The Python docs say "The returned list does not contain certificates from capath unless a certificate was requested and loaded by a SSL connection." It seems that getting the unverified cert chain with get_unverified_chain() must be sufficient for OpenSSL to do that.