### PR TITLE
Refactor to avoid using an SSLContext that wraps another SSLContext

### DIFF
--- a/src/truststore/_macos.py
+++ b/src/truststore/_macos.py
@@ -276,8 +276,12 @@ def _der_certs_to_cf_cert_array(certs: list[bytes]) -> CFMutableArrayRef:  # typ
 
 
 def _configure_context(ctx: ssl.SSLContext) -> None:
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    # To external consumers, truststore.SSLContext does not expose
+    # a way to disable cert verification. But we need to disable it
+    # within OpenSSL so that we can provide an alternate implementation.
+    # To do that we use the properties from the base class ssl.SSLContext
+    ssl.SSLContext.check_hostname.__set__(ctx, False)
+    ssl.SSLContext.verify_mode.__set__(ctx, ssl.CERT_NONE)
 
 
 def _verify_peercerts_impl(

--- a/src/truststore/_windows.py
+++ b/src/truststore/_windows.py
@@ -464,5 +464,9 @@ def _verify_using_custom_ca_certs(
 
 
 def _configure_context(ctx: ssl.SSLContext) -> None:
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
+    # To external consumers, truststore.SSLContext does not expose
+    # a way to disable cert verification. But we need to disable it
+    # within OpenSSL so that we can provide an alternate implementation.
+    # To do that we use the properties from the base class ssl.SSLContext
+    ssl.SSLContext.check_hostname.__set__(ctx, False)
+    ssl.SSLContext.verify_mode.__set__(ctx, ssl.CERT_NONE)


### PR DESCRIPTION
@sethmlarson I had an idea on the plane that it might be possible to avoid wrapping a 2nd SSLContext like this (and thus avoid needing to proxy attributes). In the end it has its own ugliness dealing with the class hierarchy. What do you think?