### PR TITLE
Adjust deploy workflow name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: PyPI
 
 on:
   push:


### PR DESCRIPTION
Gratuitous change so the github UI says "Deploying to PyPI" instead of "Deploying to Deploy"