### PR TITLE
Add nightly CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '7 5 * * *'
 
 defaults:
   run:


### PR DESCRIPTION
I'm impressed with github's UI hint when editing the cron schedule
<img width="483" alt="Screen Shot 2022-11-19 at 10 31 35 AM" src="https://user-images.githubusercontent.com/49014/202866222-ddd48315-f39f-4a9e-bced-128c2aec5a3f.png">

(:07 because the docs suggest avoiding the top of the hour which has higher traffic)