### PR TITLE
Raise an ImportError instead of OSError for unsupported macOS versions

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -76,6 +76,17 @@ http = urllib3.PoolManager(ssl_context=ctx)
 resp = http.request("GET", "https://example.com")
 ```
 
+If Truststore can't work for a given platform due to APIs not being available then
+at import time the exception `ImportError` will be raised with an informative message:
+
+```python
+# On Python 3.9 and earlier:
+import truststore  # Raises 'ImportError'
+
+# On macOS 10.7 and earlier:
+import truststore  # Raises 'ImportError'
+```
+
 ### Using truststore with pip
 
 [Pip v22.2](https://discuss.python.org/t/announcement-pip-22-2-release/17543) includes experimental support for verifying certificates with system trust stores using `truststore`. To enable the feature, use the flag `--use-feature=truststore` when installing a package like so:

--- a/src/truststore/_macos.py
+++ b/src/truststore/_macos.py
@@ -21,7 +21,7 @@ from ._ssl_constants import _set_ssl_context_verify_mode
 _mac_version = platform.mac_ver()[0]
 _mac_version_info = tuple(map(int, _mac_version.split(".")))
 if _mac_version_info < (10, 8):
-    raise OSError(
+    raise ImportError(
         f"Only OS X 10.8 and newer are supported, not {_mac_version_info[0]}.{_mac_version_info[1]}"
     )
 


### PR DESCRIPTION
See: https://github.com/pypa/pip/pull/11647#discussion_r1156170616