### PR TITLE
Include documentation and test files in sdist archives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ filterwarnings = [
   # See: aio-libs/aiohttp#7545
   "ignore:.*datetime.utcfromtimestamp().*:DeprecationWarning",
 ]
+
+[tool.flit.sdist]
+include = ["docs", "tests"]


### PR DESCRIPTION
Include documentation sources and test files in sdist archives in order to make it possible to use them to build distribution packages.