### PR TITLE
Mark tests as requiring Internet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ filterwarnings = [
   "ignore:.*datetime.utcfromtimestamp().*:DeprecationWarning",
 ]
 markers = [
-  "internet: test reqires Internet access"
+  "internet: test requires Internet access"
 ]
 
 [tool.flit.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ filterwarnings = [
   # See: aio-libs/aiohttp#7545
   "ignore:.*datetime.utcfromtimestamp().*:DeprecationWarning",
 ]
+markers = [
+  "internet: test reqires Internet access"
+]
 
 [tool.flit.sdist]
 include = ["docs", "tests"]

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -4,7 +4,7 @@ import socket
 import ssl
 import typing
 
-import _ssl  # type: ignore[import]
+import _ssl  # type: ignore[import-not-found]
 
 from ._ssl_constants import (
     _original_SSLContext,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,18 @@ SUBPROCESS_TIMEOUT = 5
 original_SSLContext = ssl.SSLContext
 
 
-successful_hosts = pytest.mark.parametrize("host", ["example.com", "1.1.1.1"])
+def decorator_requires_internet(decorator):
+    """Mark a decorator with the "internet" mark"""
+
+    def wrapper(f):
+        return pytest.mark.internet(decorator(f))
+
+    return wrapper
+
+
+successful_hosts = decorator_requires_internet(
+    pytest.mark.parametrize("host", ["example.com", "1.1.1.1"])
+)
 
 logger = logging.getLogger("aiohttp.web")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,7 @@ from OpenSSL.crypto import X509
 
 import truststore
 from tests import SSLContextAdapter
+from tests.conftest import decorator_requires_internet
 
 pytestmark = pytest.mark.flaky
 
@@ -27,7 +28,10 @@ pytestmark = pytest.mark.flaky
 # if the client drops the connection due to a cert verification error
 socket.setdefaulttimeout(10)
 
-successful_hosts = pytest.mark.parametrize("host", ["example.com", "1.1.1.1"])
+
+successful_hosts = decorator_requires_internet(
+    pytest.mark.parametrize("host", ["example.com", "1.1.1.1"])
+)
 
 
 @dataclass
@@ -118,8 +122,10 @@ failure_hosts_list = [
     ),
 ]
 
-failure_hosts_no_revocation = pytest.mark.parametrize(
-    "failure", failure_hosts_list.copy(), ids=attrgetter("host")
+failure_hosts_no_revocation = decorator_requires_internet(
+    pytest.mark.parametrize(
+        "failure", failure_hosts_list.copy(), ids=attrgetter("host")
+    )
 )
 
 if platform.system() != "Linux":
@@ -139,8 +145,8 @@ if platform.system() != "Linux":
         )
     )
 
-failure_hosts = pytest.mark.parametrize(
-    "failure", failure_hosts_list, ids=attrgetter("host")
+failure_hosts = decorator_requires_internet(
+    pytest.mark.parametrize("failure", failure_hosts_list, ids=attrgetter("host"))
 )
 
 
@@ -318,6 +324,7 @@ def test_trustme_cert_loaded_via_capath(trustme_ca, httpserver):
         assert len(resp.data) > 0
 
 
+@pytest.mark.internet
 def test_trustme_cert_still_uses_system_certs(trustme_ca):
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     trustme_ca.configure_trust(ctx)

--- a/tests/test_sslcontext.py
+++ b/tests/test_sslcontext.py
@@ -8,6 +8,7 @@ from urllib3.exceptions import InsecureRequestWarning, SSLError
 import truststore
 
 
+@pytest.mark.internet
 def test_minimum_maximum_version():
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     ctx.maximum_version = ssl.TLSVersion.TLSv1_2
@@ -24,6 +25,7 @@ def test_minimum_maximum_version():
     assert ctx.maximum_version == ssl.TLSVersion.TLSv1_2
 
 
+@pytest.mark.internet
 def test_check_hostname_false():
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     assert ctx.check_hostname is True
@@ -35,6 +37,7 @@ def test_check_hostname_false():
         assert "match" in str(e.value)
 
 
+@pytest.mark.internet
 def test_verify_mode_cert_none():
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     assert ctx.check_hostname is True


### PR DESCRIPTION
So that we can self-contained tests, when offline.

The use-case here is packaging truststore in Debian. We like to run tests during our package builds, where possible. These build environments don't permit Internet access.
We do have CI test environments that can access the Internet, but those happen after build. We'd run the full test suite there (inclnuding mkcert, which messes with the system certificate store).

I see that the vast majority of the tests require Internet access, so I understand if you're not interested in this patch, because you aren't expecting much low-level test coverage.