### PR TITLE
Raise a better exception when peer sends no certificates on Windows

### DIFF
--- a/src/truststore/_windows.py
+++ b/src/truststore/_windows.py
@@ -325,6 +325,12 @@ def _verify_peercerts_impl(
     server_hostname: str | None = None,
 ) -> None:
     """Verify the cert_chain from the server using Windows APIs."""
+
+    # If the peer didn't send any certificates then
+    # we can't do verification. Raise an error.
+    if not cert_chain:
+        raise ssl.SSLCertVerificationError("Peer sent no certificates to verify")
+
     pCertContext = None
     hIntermediateCertStore = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, None, 0, None)
     try:


### PR DESCRIPTION
Closes https://github.com/sethmlarson/truststore/issues/128

I'm not sure we'll be able to test this without a different test fixture. Python doesn't seem to like being configured as a server SSLContext without any certificates loaded (errors on server-side with "no cipher overlap")