### PR TITLE
Fix the `aiohttp` examples to clean up resources

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -140,8 +140,9 @@ import truststore
 
 truststore.inject_into_ssl()
 
-http = aiohttp.ClientSession()
-resp = await http.request("GET", "https://example.com")
+async with aiohttp.ClientSession() as http_client:
+    async with http_client.get("https://example.com") as http_response:
+        ...
 ```
 
 If you'd like to use the `truststore.SSLContext` directly you can pass
@@ -154,8 +155,9 @@ import truststore
 
 ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
-http = aiohttp.ClientSession(ssl=ctx)
-resp = await http.request("GET", "https://example.com")
+async with aiohttp.ClientSession(ssl=ctx) as http_client:
+    async with http_client.get("https://example.com") as http_response:
+        ...
 ```
 
 ### Using truststore with Requests


### PR DESCRIPTION
The previously present snippets presented a misuse of `aiohttp`'s APIs. While technically they work, they don't release the allocated resources like async CMs would. And so we recommend using the latter.

Ref https://github.com/aio-libs/aiohttp/issues/8430#issuecomment-2139581921.