### PR TITLE
test_requests_works_with_inject() needs Internet access

### DIFF
--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -99,6 +99,7 @@ async def test_aiohttp_works_with_inject(server: Server) -> None:
         assert resp.status == 200
 
 
+@pytest.mark.internet
 def test_requests_works_with_inject() -> None:
     # We completely isolate the requests module because
     # pytest or some other part of our test infra is messing


### PR DESCRIPTION
14078644429f8730c5af2138e727f8f7b225d2fb migrated the test from using the local server to using example.com, but missed a tag.