### PR TITLE
Enable disabling hostname verification for macOS and Windows

### DIFF
--- a/src/truststore/_macos.py
+++ b/src/truststore/_macos.py
@@ -386,7 +386,9 @@ def _verify_peercerts_impl(
     policies = None
     trust = None
     try:
-        if server_hostname is not None:
+        # Only set a hostname on the policy if we're verifying the hostname
+        # on the leaf certificate.
+        if server_hostname is not None and ssl_context.check_hostname:
             cf_str_hostname = None
             try:
                 cf_str_hostname = _bytes_to_cf_string(server_hostname.encode("ascii"))
@@ -537,11 +539,6 @@ def _verify_peercerts_impl_macos_10_14(
         if ssl_context.verify_mode != ssl.CERT_REQUIRED and (
             cf_error_code == CFConst.errSecNotTrusted
             or cf_error_code == CFConst.errSecCertificateExpired
-        ):
-            is_trusted = True
-        elif (
-            not ssl_context.check_hostname
-            and cf_error_code == CFConst.errSecHostNameMismatch
         ):
             is_trusted = True
 

--- a/src/truststore/_windows.py
+++ b/src/truststore/_windows.py
@@ -212,6 +212,7 @@ CERT_CHAIN_POLICY_IGNORE_INVALID_POLICY_FLAG = 0x00000080
 CERT_CHAIN_POLICY_IGNORE_ALL_REV_UNKNOWN_FLAGS = 0x00000F00
 CERT_CHAIN_POLICY_ALLOW_TESTROOT_FLAG = 0x00008000
 CERT_CHAIN_POLICY_TRUST_TESTROOT_FLAG = 0x00004000
+SECURITY_FLAG_IGNORE_CERT_CN_INVALID = 0x00001000
 AUTHTYPE_SERVER = 2
 CERT_CHAIN_POLICY_SSL = 4
 FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000
@@ -443,6 +444,10 @@ def _get_and_verify_cert_chain(
         )
         ssl_extra_cert_chain_policy_para.dwAuthType = AUTHTYPE_SERVER
         ssl_extra_cert_chain_policy_para.fdwChecks = 0
+        if ssl_context.check_hostname is False:
+            ssl_extra_cert_chain_policy_para.fdwChecks = (
+                SECURITY_FLAG_IGNORE_CERT_CN_INVALID
+            )
         if server_hostname:
             ssl_extra_cert_chain_policy_para.pwszServerName = c_wchar_p(server_hostname)
 
@@ -452,8 +457,6 @@ def _get_and_verify_cert_chain(
         )
         if ssl_context.verify_mode == ssl.CERT_NONE:
             chain_policy.dwFlags |= CERT_CHAIN_POLICY_VERIFY_MODE_NONE_FLAGS
-        if not ssl_context.check_hostname:
-            chain_policy.dwFlags |= CERT_CHAIN_POLICY_IGNORE_INVALID_NAME_FLAG
         chain_policy.cbSize = sizeof(chain_policy)
 
         pPolicyPara = pointer(chain_policy)


### PR DESCRIPTION
Currently we "disable" hostname verification on macOS by ignoring a hostname mismatch error. Instead we can not set a policy to check the hostname, then we don't need to ignore any errors for this functionality.

For Windows, instead of ignoring all name errors for certificates we can ignore only a mismatch.