### PR TITLE
Use the 'SecTrustEvaluate' API for macOS 10.13 and earlier

### DIFF
--- a/src/truststore/_macos.py
+++ b/src/truststore/_macos.py
@@ -473,7 +473,8 @@ def _verify_peercerts_impl_macos_10_13(
     except (ValueError, TypeError):
         sec_trust_result_type_as_int = -1
 
-    # See: https://developer.apple.com/documentation/security/sectrustevaluate(_:_:)?language=objc
+    # Apple doesn't document these values in their own API docs.
+    # See: https://github.com/xybp888/iOS-SDKs/blob/master/iPhoneOS13.0.sdk/System/Library/Frameworks/Security.framework/Headers/SecTrust.h#L84
     if (
         ssl_context.verify_mode == ssl.CERT_REQUIRED
         and sec_trust_result_type_as_int not in (1, 4)
@@ -484,12 +485,12 @@ def _verify_peercerts_impl_macos_10_13(
         sec_trust_result_type_to_message = {
             0: "Invalid trust result type",
             # 1: "Trust evaluation succeeded",
-            2: "Trust was explicitly denied",
-            3: "Fatal trust failure occurred",
-            # 4: "Trust result is unspecified (but trusted)",
+            2: "User confirmation required",
+            3: "User specified that certificate is not trusted",
+            # 4: "Trust result is unspecified",
             5: "Recoverable trust failure occurred",
-            6: "Unknown error occurred",
-            7: "User confirmation required",
+            6: "Fatal trust failure occurred",
+            7: "Other error occurred, certificate may be revoked",
         }
         error_message = sec_trust_result_type_to_message.get(
             sec_trust_result_type_as_int,

--- a/src/truststore/_macos.py
+++ b/src/truststore/_macos.py
@@ -123,12 +123,6 @@ try:
     ]
     Security.SecTrustEvaluate.restype = OSStatus
 
-    Security.SecTrustEvaluateWithError.argtypes = [
-        SecTrustRef,
-        POINTER(CFErrorRef),
-    ]
-    Security.SecTrustEvaluateWithError.restype = c_bool
-
     Security.SecTrustRef = SecTrustRef  # type: ignore[attr-defined]
     Security.SecTrustResultType = SecTrustResultType  # type: ignore[attr-defined]
     Security.OSStatus = OSStatus  # type: ignore[attr-defined]
@@ -211,8 +205,19 @@ try:
     CoreFoundation.CFStringRef = CFStringRef  # type: ignore[attr-defined]
     CoreFoundation.CFErrorRef = CFErrorRef  # type: ignore[attr-defined]
 
-except AttributeError:
-    raise ImportError("Error initializing ctypes") from None
+except AttributeError as e:
+    raise ImportError(f"Error initializing ctypes: {e}") from None
+
+# SecTrustEvaluateWithError is macOS 10.14+
+if _is_macos_version_10_14_or_later:
+    try:
+        Security.SecTrustEvaluateWithError.argtypes = [
+            SecTrustRef,
+            POINTER(CFErrorRef),
+        ]
+        Security.SecTrustEvaluateWithError.restype = c_bool
+    except AttributeError as e:
+        raise ImportError(f"Error initializing ctypes: {e}") from None
 
 
 def _handle_osstatus(result: OSStatus, _: typing.Any, args: typing.Any) -> typing.Any:

--- a/src/truststore/_macos.py
+++ b/src/truststore/_macos.py
@@ -115,6 +115,18 @@ try:
     ]
     Security.SecTrustGetTrustResult.restype = OSStatus
 
+    Security.SecTrustEvaluate.argtypes = [
+        SecTrustRef,
+        POINTER(SecTrustResultType),
+    ]
+    Security.SecTrustEvaluate.restype = OSStatus
+
+    Security.SecTrustEvaluateWithError.argtypes = [
+        SecTrustRef,
+        POINTER(CFErrorRef),
+    ]
+    Security.SecTrustEvaluateWithError.restype = c_bool
+
     Security.SecTrustRef = SecTrustRef  # type: ignore[attr-defined]
     Security.SecTrustResultType = SecTrustResultType  # type: ignore[attr-defined]
     Security.OSStatus = OSStatus  # type: ignore[attr-defined]
@@ -258,6 +270,7 @@ Security.SecTrustCreateWithCertificates.errcheck = _handle_osstatus  # type: ign
 Security.SecTrustSetAnchorCertificates.errcheck = _handle_osstatus  # type: ignore[assignment]
 Security.SecTrustSetAnchorCertificatesOnly.errcheck = _handle_osstatus  # type: ignore[assignment]
 Security.SecTrustGetTrustResult.errcheck = _handle_osstatus  # type: ignore[assignment]
+Security.SecTrustEvaluate.errcheck = _handle_osstatus  # type: ignore[assignment]
 
 
 class CFConst:
@@ -365,7 +378,6 @@ def _verify_peercerts_impl(
     certs = None
     policies = None
     trust = None
-    cf_error = None
     try:
         if server_hostname is not None:
             cf_str_hostname = None
@@ -431,69 +443,116 @@ def _verify_peercerts_impl(
         # We always want system certificates.
         Security.SecTrustSetAnchorCertificatesOnly(trust, False)
 
-        cf_error = CoreFoundation.CFErrorRef()
-        sec_trust_eval_result = Security.SecTrustEvaluateWithError(
-            trust, ctypes.byref(cf_error)
-        )
-        # sec_trust_eval_result is a bool (0 or 1)
-        # where 1 means that the certs are trusted.
-        if sec_trust_eval_result == 1:
-            is_trusted = True
-        elif sec_trust_eval_result == 0:
-            is_trusted = False
+        # macOS 10.12 and earlier don't support SecTrustEvaluateWithError()
+        # so we use SecTrustEvaluate() which means we need to construct error
+        # messages ourselves.
+        if 1 or _mac_version_info < (10, 12):
+            _verify_peercerts_impl_macos_10_12(trust)
         else:
-            raise ssl.SSLError(
-                f"Unknown result from Security.SecTrustEvaluateWithError: {sec_trust_eval_result!r}"
-            )
-
-        cf_error_code = 0
-        if not is_trusted:
-            cf_error_code = CoreFoundation.CFErrorGetCode(cf_error)
-
-            # If the error is a known failure that we're
-            # explicitly okay with from SSLContext configuration
-            # we can set is_trusted accordingly.
-            if ssl_context.verify_mode != ssl.CERT_REQUIRED and (
-                cf_error_code == CFConst.errSecNotTrusted
-                or cf_error_code == CFConst.errSecCertificateExpired
-            ):
-                is_trusted = True
-            elif (
-                not ssl_context.check_hostname
-                and cf_error_code == CFConst.errSecHostNameMismatch
-            ):
-                is_trusted = True
-
-        # If we're still not trusted then we start to
-        # construct and raise the SSLCertVerificationError.
-        if not is_trusted:
-            cf_error_string_ref = None
-            try:
-                cf_error_string_ref = CoreFoundation.CFErrorCopyDescription(cf_error)
-
-                # Can this ever return 'None' if there's a CFError?
-                cf_error_message = (
-                    _cf_string_ref_to_str(cf_error_string_ref)
-                    or "Certificate verification failed"
-                )
-
-                # TODO: Not sure if we need the SecTrustResultType for anything?
-                # We only care whether or not it's a success or failure for now.
-                sec_trust_result_type = Security.SecTrustResultType()
-                Security.SecTrustGetTrustResult(
-                    trust, ctypes.byref(sec_trust_result_type)
-                )
-
-                err = ssl.SSLCertVerificationError(cf_error_message)
-                err.verify_message = cf_error_message
-                err.verify_code = cf_error_code
-                raise err
-            finally:
-                if cf_error_string_ref:
-                    CoreFoundation.CFRelease(cf_error_string_ref)
-
+            _verify_peercerts_impl_macos_10_13(ssl_context, trust)
     finally:
         if policies:
             CoreFoundation.CFRelease(policies)
         if trust:
             CoreFoundation.CFRelease(trust)
+
+
+def _verify_peercerts_impl_macos_10_12(sec_trust_ref: typing.Any) -> None:
+    """Verify using 'SecTrustEvaluate' API for macOS 10.12 and earlier.
+    macOS 10.13 added the 'SecTrustEvaluateWithError' API.
+    """
+    sec_trust_result_type = Security.SecTrustResultType()
+    Security.SecTrustEvaluate(sec_trust_ref, ctypes.byref(sec_trust_result_type))
+
+    try:
+        sec_trust_result_type_as_int = int(sec_trust_result_type.value)
+    except (ValueError, TypeError):
+        sec_trust_result_type_as_int = -1
+
+    # See: https://developer.apple.com/documentation/security/sectrustevaluate(_:_:)?language=objc
+    if sec_trust_result_type_as_int not in (1, 4):
+        sec_trust_result_type_to_message = {
+            0: "Invalid trust result type",
+            # 1: "Trust evaluation succeeded",
+            2: "Trust was explicitly denied",
+            3: "Fatal trust failure occurred",
+            # 4: "Trust result is unspecified (but trusted)",
+            5: "Recoverable trust failure occurred",
+            6: "Unknown error occurred",
+            7: "User confirmation required",
+        }
+        error_message = sec_trust_result_type_to_message.get(
+            sec_trust_result_type_as_int,
+            f"Unknown trust result: {sec_trust_result_type_as_int}",
+        )
+
+        err = ssl.SSLCertVerificationError(error_message)
+        err.verify_message = error_message
+        err.verify_code = sec_trust_result_type_as_int
+        raise err
+
+
+def _verify_peercerts_impl_macos_10_13(
+    ssl_context: ssl.SSLContext, sec_trust_ref: typing.Any
+) -> None:
+    """Verify using 'SecTrustEvaluateWithError' API for macOS 10.13+."""
+    cf_error = CoreFoundation.CFErrorRef()
+    sec_trust_eval_result = Security.SecTrustEvaluateWithError(
+        sec_trust_ref, ctypes.byref(cf_error)
+    )
+    # sec_trust_eval_result is a bool (0 or 1)
+    # where 1 means that the certs are trusted.
+    if sec_trust_eval_result == 1:
+        is_trusted = True
+    elif sec_trust_eval_result == 0:
+        is_trusted = False
+    else:
+        raise ssl.SSLError(
+            f"Unknown result from Security.SecTrustEvaluateWithError: {sec_trust_eval_result!r}"
+        )
+
+    cf_error_code = 0
+    if not is_trusted:
+        cf_error_code = CoreFoundation.CFErrorGetCode(cf_error)
+
+        # If the error is a known failure that we're
+        # explicitly okay with from SSLContext configuration
+        # we can set is_trusted accordingly.
+        if ssl_context.verify_mode != ssl.CERT_REQUIRED and (
+            cf_error_code == CFConst.errSecNotTrusted
+            or cf_error_code == CFConst.errSecCertificateExpired
+        ):
+            is_trusted = True
+        elif (
+            not ssl_context.check_hostname
+            and cf_error_code == CFConst.errSecHostNameMismatch
+        ):
+            is_trusted = True
+
+    # If we're still not trusted then we start to
+    # construct and raise the SSLCertVerificationError.
+    if not is_trusted:
+        cf_error_string_ref = None
+        try:
+            cf_error_string_ref = CoreFoundation.CFErrorCopyDescription(cf_error)
+
+            # Can this ever return 'None' if there's a CFError?
+            cf_error_message = (
+                _cf_string_ref_to_str(cf_error_string_ref)
+                or "Certificate verification failed"
+            )
+
+            # TODO: Not sure if we need the SecTrustResultType for anything?
+            # We only care whether or not it's a success or failure for now.
+            sec_trust_result_type = Security.SecTrustResultType()
+            Security.SecTrustGetTrustResult(
+                sec_trust_ref, ctypes.byref(sec_trust_result_type)
+            )
+
+            err = ssl.SSLCertVerificationError(cf_error_message)
+            err.verify_message = cf_error_message
+            err.verify_code = cf_error_code
+            raise err
+        finally:
+            if cf_error_string_ref:
+                CoreFoundation.CFRelease(cf_error_string_ref)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -145,7 +145,7 @@ if platform.system() != "Linux":
                 # macOS
                 "“revoked.badssl.com” certificate is revoked",
                 # macOS 10.13
-                "Unknown error occurred",
+                "Other error occurred, certificate may be revoked",
                 # Windows
                 "The certificate is revoked.",
             ],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -145,7 +145,7 @@ if platform.system() != "Linux":
                 # macOS
                 "“revoked.badssl.com” certificate is revoked",
                 # macOS 10.13
-                "Other error occurred, certificate may be revoked",
+                "Fatal trust failure occurred",
                 # Windows
                 "The certificate is revoked.",
             ],
@@ -157,7 +157,7 @@ failure_hosts = decorator_requires_internet(
 )
 
 # Fixture which tests both the SecTrustEvaluate (macOS <=10.13) and
-# SecTrustEvaluteWithError (macOS >=10.14) APIs
+# SecTrustEvaluateWithError (macOS >=10.14) APIs
 # on macOS versions that support both APIs.
 if platform.system() == "Darwin" and tuple(
     map(int, platform.mac_ver()[0].split("."))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,7 +49,7 @@ failure_hosts_list = [
             "certificate name does not match",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
-            # macOS 10.12
+            # macOS 10.13
             "Recoverable trust failure occurred",
             # Windows
             "The certificate's CN name does not match the passed value.",
@@ -64,7 +64,7 @@ failure_hosts_list = [
             "“*.badssl.com” certificate is expired",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
-            # macOS 10.12
+            # macOS 10.13
             "Recoverable trust failure occurred",
             # Windows
             (
@@ -83,7 +83,7 @@ failure_hosts_list = [
             "“*.badssl.com” certificate is not trusted",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
-            # macOS 10.12
+            # macOS 10.13
             "Recoverable trust failure occurred",
             # Windows
             (
@@ -102,7 +102,7 @@ failure_hosts_list = [
             "“BadSSL Untrusted Root Certificate Authority” certificate is not trusted",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
-            # macOS 10.12
+            # macOS 10.13
             "Recoverable trust failure occurred",
             # Windows
             (
@@ -120,7 +120,7 @@ failure_hosts_list = [
             "“superfish.badssl.com” certificate is not trusted",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
-            # macOS 10.12
+            # macOS 10.13
             "Recoverable trust failure occurred",
             # Windows
             (
@@ -144,7 +144,7 @@ if platform.system() != "Linux":
             error_messages=[
                 # macOS
                 "“revoked.badssl.com” certificate is revoked",
-                # macOS 10.12
+                # macOS 10.13
                 "Unknown error occurred",
                 # Windows
                 "The certificate is revoked.",
@@ -155,6 +155,24 @@ if platform.system() != "Linux":
 failure_hosts = decorator_requires_internet(
     pytest.mark.parametrize("failure", failure_hosts_list, ids=attrgetter("host"))
 )
+
+# Fixture which tests both the SecTrustEvaluate (macOS <=10.13) and
+# SecTrustEvaluteWithError (macOS >=10.14) APIs
+# on macOS versions that support both APIs.
+if platform.system() == "Darwin" and tuple(
+    map(int, platform.mac_ver()[0].split("."))
+) >= (10, 14):
+
+    @pytest.fixture(autouse=True, params=[True, False])
+    def mock_macos_version_10_13(request):
+        import truststore._macos
+
+        prev = truststore._macos._is_macos_version_10_14_or_later
+        truststore._macos._is_macos_version_10_14_or_later = request.param
+        try:
+            yield
+        finally:
+            truststore._macos._is_macos_version_10_14_or_later = prev
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,6 +49,8 @@ failure_hosts_list = [
             "certificate name does not match",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
+            # macOS 10.12
+            "Recoverable trust failure occurred",
             # Windows
             "The certificate's CN name does not match the passed value.",
         ],
@@ -62,6 +64,8 @@ failure_hosts_list = [
             "“*.badssl.com” certificate is expired",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
+            # macOS 10.12
+            "Recoverable trust failure occurred",
             # Windows
             (
                 "A required certificate is not within its validity period when verifying "
@@ -79,6 +83,8 @@ failure_hosts_list = [
             "“*.badssl.com” certificate is not trusted",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
+            # macOS 10.12
+            "Recoverable trust failure occurred",
             # Windows
             (
                 "A certificate chain processed, but terminated in a root "
@@ -96,6 +102,8 @@ failure_hosts_list = [
             "“BadSSL Untrusted Root Certificate Authority” certificate is not trusted",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
+            # macOS 10.12
+            "Recoverable trust failure occurred",
             # Windows
             (
                 "A certificate chain processed, but terminated in a root "
@@ -112,6 +120,8 @@ failure_hosts_list = [
             "“superfish.badssl.com” certificate is not trusted",
             # macOS with revocation checks
             "certificates do not meet pinning requirements",
+            # macOS 10.12
+            "Recoverable trust failure occurred",
             # Windows
             (
                 "A certificate chain processed, but terminated in a root "
@@ -134,6 +144,8 @@ if platform.system() != "Linux":
             error_messages=[
                 # macOS
                 "“revoked.badssl.com” certificate is revoked",
+                # macOS 10.12
+                "Unknown error occurred",
                 # Windows
                 "The certificate is revoked.",
             ],


### PR DESCRIPTION
Closes #119. This uses the patch provided by @illume as a baseline.