### PR TITLE
Use separate injection script for aiohttp test case

### DIFF
--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -169,6 +169,9 @@ class SSLContext(_truststore_SSLContext_super_class):  # type: ignore[misc]
     def cert_store_stats(self) -> dict[str, int]:
         raise NotImplementedError()
 
+    def set_default_verify_paths(self) -> None:
+        self._ctx.set_default_verify_paths()
+
     @typing.overload
     def get_ca_certs(
         self, binary_form: typing.Literal[False] = ...

--- a/tests/aiohttp_with_inject.py
+++ b/tests/aiohttp_with_inject.py
@@ -1,0 +1,20 @@
+# Used by the test: test_inject.py::test_aiohttp_work_with_inject
+
+import asyncio
+import sys
+
+import truststore
+
+truststore.inject_into_ssl()
+
+import aiohttp  # noqa: E402
+
+
+async def main():
+    async with aiohttp.ClientSession() as client:
+        resp = await client.get("https://localhost:9999")
+        assert resp.status == 200
+        sys.exit(resp.status)
+
+
+asyncio.run(main())

--- a/tests/requests_with_inject.py
+++ b/tests/requests_with_inject.py
@@ -1,10 +1,14 @@
 # Used by the test: test_inject.py::test_requests_work_with_inject
 
+import sys
+
 import truststore
 
 truststore.inject_into_ssl()
 
 import requests  # noqa: E402
 
-resp = requests.request("GET", "https://example.com")
+resp = requests.request("GET", "https://localhost:9999")
 assert resp.status_code == 200
+
+sys.exit(resp.status_code)


### PR DESCRIPTION
Also moves both aiohttp and Requests to use the custom mkcert CA. Discovered that aiohttp is now caching their default SSLContext which is why we were seeing that test case start to fail a little over a month ago now.