### PR TITLE
Enable revocation checks for revoked test case

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -257,6 +257,8 @@ def test_failure_after_loading_additional_anchors(failure, trustme_ca):
         socket.create_connection((failure.host, 443)) as sock,
     ):
         ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        if platform.system() != "Linux":
+            ctx.verify_flags |= ssl.VERIFY_CRL_CHECK_CHAIN
 
         # See if loading additional anchors still fails.
         trustme_ca.configure_trust(ctx)


### PR DESCRIPTION
Solves the failure seen here: https://github.com/sethmlarson/truststore/actions/runs/11486776583/job/31969808273?pr=158#step:7:169 This flag is applied for `connect_to_host` but we're not using that function for this test case so we need to do it again.