### PR TITLE
Declare the desired asyncio_default_fixture_loop_scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ Documentation = "https://truststore.readthedocs.io"
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
   "error",
   # See: aio-libs/aiohttp#7545


### PR DESCRIPTION
pytest-asyncio is moving towards defaulting to the function scope. Select this now.