### PR TITLE
fix: Patch preloaded SSL context for requests library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
   compileall:
     # Run 'python -m compileall' on an old Python version
     # to ensure that pip can vendor truststore successfully.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # pin to 22.04, as with 24.04 Python 3.7 is no longer available
     name: compileall
     steps:
       - uses: actions/checkout@v4

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -34,7 +34,6 @@ def inject_into_ssl() -> None:
     module by replacing :class:`ssl.SSLContext`.
     """
     setattr(ssl, "SSLContext", SSLContext)
-
     # urllib3 holds on to its own reference of ssl.SSLContext
     # so we need to replace that reference too.
     try:

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -5,7 +5,7 @@ import ssl
 import sys
 import typing
 
-import _ssl  # type: ignore[import-not-found]
+import _ssl
 
 from ._ssl_constants import (
     _original_SSLContext,

--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -43,7 +43,7 @@ def inject_into_ssl() -> None:
     except ImportError:
         pass
 
-    # requests starting with 3.23.0 added a preloaded SSL context to improve concurrent performance;
+    # requests starting with 2.32.0 added a preloaded SSL context to improve concurrent performance;
     # this unfortunately leads to a RecursionError, which can be avoided by patching the preloaded SSL context with
     # the truststore patched instance
     # also see https://github.com/psf/requests/pull/6667


### PR DESCRIPTION
requests [2.32.0 ](https://github.com/psf/requests/releases/tag/v2.32.0) introduced a [preloaded SSL context](https://github.com/psf/requests/pull/6667/files#diff-a4598bf8444e0feca489e60704c809c0dbfc47b90c4364216c931b497b3312d7R75-R78), which needs to be patched manually unfortunately.

This PR adds the according functionality.

Fixes https://github.com/sethmlarson/truststore/issues/165
Fixes https://github.com/sethmlarson/truststore/issues/143