### PR TITLE
perf: don't check for peer certificate chain APIs on CPython/PyPy

### DIFF
--- a/src/truststore/__init__.py
+++ b/src/truststore/__init__.py
@@ -7,7 +7,7 @@ if _sys.version_info < (3, 10):
 
 # Detect Python runtimes which don't implement SSLObject.get_unverified_chain() API
 # This API only became public in Python 3.13 but was available in CPython and PyPy since 3.10.
-if _sys.version_info < (3, 13):
+if _sys.version_info < (3, 13) and _sys.implementation.name not in ("cpython", "pypy"):
     try:
         import ssl as _ssl
     except ImportError:


### PR DESCRIPTION
create_default_context() is quite slow on Linux as OpenSSL 3.x verify location loading is painfully slow. I've observed ~15 ms per call.

On CPython and PyPy, we can skip this check since we already know the required APIs exist.

This is part of my goal of reducing pip's startup time.