### PR TITLE
Allow 403 responses from Cloudflare

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -291,7 +291,9 @@ def test_sslcontext_api_success(host):
     ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     with urllib3.PoolManager(ssl_context=ctx, retries=5) as http:
         resp = http.request("GET", f"https://{host}")
-    assert resp.status == 200
+    # Cloudflare rejects some of our CI requests and
+    # that's okay because we only care about the TLS handshake.
+    assert resp.status in (200, 403)
     assert len(resp.data) > 0
 
 


### PR DESCRIPTION
Sometimes [Cloudflare gets upset at us](https://github.com/sethmlarson/truststore/actions/runs/13090946000/job/36527479326#step:7:222), but we don't care about the HTTP status code. We're here for the handshake :handshake: 