### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     name: "Lint"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.x
-      - uses: pre-commit/action@v3.0.1
-
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   test:
     strategy:
       fail-fast: false
@@ -40,16 +39,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: 1.x
 
@@ -80,8 +78,8 @@ jobs:
     runs-on: ubuntu-22.04 # pin to 22.04, as with 24.04 Python 3.7 is no longer available
     name: compileall
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.7"
       - run: |
@@ -93,18 +91,18 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           path: truststore
 
       - name: Checkout pypa/pip
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: pypa/pip
           path: pip
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: PyPI
-
 on:
   push:
     tags: v[0-9]+.[0-9]+.[0-9]+
-
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -13,10 +11,9 @@ jobs:
       id-token: write
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b"
-
+        uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4
       - name: "Setup Python"
-        uses: "actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435"
+        uses: "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" # v5.6.0
         with:
           python-version: "3.x"
 
@@ -27,4 +24,4 @@ jobs:
           python -m build
 
       - name: "Publish dists to PyPI"
-        uses: "pypa/gh-action-pypi-publish@48b317d84d5f59668bb13be49d1697e36b3ad009"
+        uses: "pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011" # v1.12.4


### PR DESCRIPTION
Our `pypa/gh-actions-pypi-publish` action was out of date, meaning the new metadata version (2.4) wasn't supported. Upgraded and pinned all of our actions using `frizbee`.