### PR TITLE
Repin gh-actions-pypi-publish workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,4 @@ jobs:
           python -m build
 
       - name: "Publish dists to PyPI"
-        uses: "pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011" # v1.12.4
+        uses: "pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc" # v1.12.4


### PR DESCRIPTION
Manually pinned the commit instead of using Frizbee. I'm not sure why Frizbee selected this commit, my best guess is that a force-push happened upstream on the workflow.