### PR TITLE
Fix 'One or more parameters passed to a function were not valid.' in …

### DIFF
--- a/src/truststore/_api.py
+++ b/src/truststore/_api.py
@@ -334,6 +334,12 @@ def _verify_peercerts(
         pass
 
     cert_bytes = _get_unverified_chain_bytes(sslobj)
+
+    # If the peer didn't send any certificates then
+    # we can't do verification. Raise an error.
+    if not cert_bytes:
+        raise ssl.SSLCertVerificationError("Peer sent no certificates to verify")
+
     _verify_peercerts_impl(
         sock_or_sslobj.context, cert_bytes, server_hostname=server_hostname
     )

--- a/src/truststore/_macos.py
+++ b/src/truststore/_macos.py
@@ -382,7 +382,13 @@ def _verify_peercerts_impl(
     cert_chain: list[bytes],
     server_hostname: str | None = None,
 ) -> None:
-    certs = None
+    """Verify the cert_chain from the server using macOS APIs."""
+
+    # If the peer didn't send any certificates then
+    # we can't do verification. Raise an error.
+    if not cert_chain:
+        raise ssl.SSLCertVerificationError("Peer sent no certificates to verify")
+
     policies = None
     trust = None
     try:

--- a/src/truststore/_macos.py
+++ b/src/truststore/_macos.py
@@ -384,11 +384,6 @@ def _verify_peercerts_impl(
 ) -> None:
     """Verify the cert_chain from the server using macOS APIs."""
 
-    # If the peer didn't send any certificates then
-    # we can't do verification. Raise an error.
-    if not cert_chain:
-        raise ssl.SSLCertVerificationError("Peer sent no certificates to verify")
-
     policies = None
     trust = None
     try:

--- a/src/truststore/_windows.py
+++ b/src/truststore/_windows.py
@@ -327,11 +327,6 @@ def _verify_peercerts_impl(
 ) -> None:
     """Verify the cert_chain from the server using Windows APIs."""
 
-    # If the peer didn't send any certificates then
-    # we can't do verification. Raise an error.
-    if not cert_chain:
-        raise ssl.SSLCertVerificationError("Peer sent no certificates to verify")
-
     pCertContext = None
     hIntermediateCertStore = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, None, 0, None)
     try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -456,7 +456,7 @@ def test_macos_10_7_import_error():
 
 
 @pytest.mark.parametrize("empty_value", [None, []])
-def test_verify_peercerts_no_cert_chain_raises(monkeypatch):
+def test_verify_peercerts_no_cert_chain_raises(monkeypatch, empty_value):
     # Simulate no certs returned from peer
     monkeypatch.setattr(api, "_get_unverified_chain_bytes", lambda sslobj: empty_value)
 
@@ -479,4 +479,3 @@ def test_verify_peercerts_no_cert_chain_raises(monkeypatch):
         api._verify_peercerts(sslobj, server_hostname="example.com")
 
     assert called is False
-    

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,7 @@ import urllib3.exceptions
 from pytest_httpserver import HTTPServer
 
 import truststore
+import truststore._api as api
 from tests import SSLContextAdapter
 from tests.conftest import decorator_requires_internet
 
@@ -452,3 +453,30 @@ def test_macos_10_7_import_error():
             importlib.reload(truststore._macos)
 
         assert str(e.value) == "Only OS X 10.8 and newer are supported, not 10.7"
+
+
+@pytest.mark.parametrize("empty_value", [None, []])
+def test_verify_peercerts_no_cert_chain_raises(monkeypatch):
+    # Simulate no certs returned from peer
+    monkeypatch.setattr(api, "_get_unverified_chain_bytes", lambda sslobj: empty_value)
+
+    # Track whether impl gets called (it shouldn't)
+    called = False
+
+    def fake_impl(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(api, "_verify_peercerts_impl", fake_impl)
+
+    class DummySSLObject:
+        def __init__(self):
+            self.context = object()
+
+    sslobj = DummySSLObject()
+
+    with pytest.raises(ssl.SSLCertVerificationError, match="Peer sent no certificates"):
+        api._verify_peercerts(sslobj, server_hostname="example.com")
+
+    assert called is False
+    


### PR DESCRIPTION
…case there are no certificates to verify.

This mimics the Windows implementation by performing the emptiness check in the caller.

This issue is reported in https://github.com/sethmlarson/truststore/issues/205 and  https://github.com/sethmlarson/truststore/issues/204
